### PR TITLE
fix(account): prevent UpdateStatus from updating Admin role accounts

### DIFF
--- a/BusinessObjects/Constants/ApplicationConstants.cs
+++ b/BusinessObjects/Constants/ApplicationConstants.cs
@@ -138,6 +138,7 @@ namespace BusinessObjects.Constants
         public const string INVALID_STATUS = "Trạng thái không hợp lệ";
         public const string UPDATE_STATUS_SUCCESS = "Cập nhật trạng thái người dùng thành công";
         public const string STATUS_NOT_CHANGED = "Trạng thái người dùng không thay đổi";
+        public const string CANNOT_CHANGE_ADMIN_STATUS = "Không thể thay đổi trạng thái của quản trị viên";
     }
     public class ResponseMessageImage
     {

--- a/Services/Services/AccountService/AccountService.cs
+++ b/Services/Services/AccountService/AccountService.cs
@@ -1029,6 +1029,16 @@ namespace Services.Services.AccountService
                         StatusCode = StatusCodes.Status404NotFound
                     };
                 }
+                if (existingUser.Role == RoleEnums.Admin.ToString())
+                {
+                    return new ResultModel
+                    {
+                        IsSuccess = false,
+                        ResponseCode = ResponseCodeConstants.BAD_REQUEST,
+                        Message = ResponseMessageConstantsUser.CANNOT_CHANGE_ADMIN_STATUS,
+                        StatusCode = StatusCodes.Status400BadRequest
+                    };
+                }
 
                 if (existingUser.Status == updateStatusRequest.Status.ToString())
                 {


### PR DESCRIPTION
- Added validation in UpdateStatus to disallow updating accounts with role Admin  
- Ensured system integrity by protecting Admin role from status changes  
