### PR TITLE
feat(form): add business hours validation and auto-approve rule in AddForm

### DIFF
--- a/BusinessObjects/Constants/ApplicationConstants.cs
+++ b/BusinessObjects/Constants/ApplicationConstants.cs
@@ -220,6 +220,7 @@ namespace BusinessObjects.Constants
         public const string GET_FORM_SUCCESS = "Lấy biểu mẫu thành công";
         public const string DELETE_FORM_FAILED = "Xóa biểu mẫu thất bại";
         public const string INVALID_FORM_DATE = "Ngày biểu mẫu không hợp lệ";
+        public const string INVALID_FORM_TIME = "Thời gian không nằm trong giờ hành chính (7h30–12h, 13h30–17h).";
     }
     // For Package (0-0-1)
     public static class ResponseMessageConstantsPackage

--- a/BusinessObjects/Enums/FormStatusEnums.cs
+++ b/BusinessObjects/Enums/FormStatusEnums.cs
@@ -10,6 +10,7 @@ namespace BusinessObjects.Enums
     {
         Draft,
         Submitted,
+        SubmittedPaidFirst,
         Pending,
         Approved,   
         Rejected,

--- a/Repositories/Repositories/FormRepo/FormRepo.cs
+++ b/Repositories/Repositories/FormRepo/FormRepo.cs
@@ -55,5 +55,12 @@ namespace Repositories.Repositories.FormRepo
             await _context.SaveChangesAsync();
             return form;
         }
+        public async Task<List<Form>> GetFormsByAccountAndStation(string accountId, string stationId)
+        {
+            return await _context.Forms
+                .Where(f => f.AccountId == accountId && f.StationId == stationId)
+                .ToListAsync();
+        }
+
     }
 }

--- a/Repositories/Repositories/FormRepo/IFormRepo.cs
+++ b/Repositories/Repositories/FormRepo/IFormRepo.cs
@@ -15,5 +15,6 @@ namespace Repositories.Repositories.FormRepo
         Task<List<Form>> GetByAccountId(string accountId);
         Task<List<Form>> GetByStationId(string stationId);
         Task<Form> Update(Form form);
+        Task<List<Form>> GetFormsByAccountAndStation(string accountId, string stationId);
     }
 }


### PR DESCRIPTION
- Added validation in AddForm to allow creation only during business hours (7h30 - 17h)
- Implemented rule: if customer has 3 prior successful payments at the same station, subsequent forms will be auto-approved
- Applied changes directly in FormService.AddForm